### PR TITLE
v1.2.5

### DIFF
--- a/.versions
+++ b/.versions
@@ -32,7 +32,7 @@ minimongo@1.0.8
 mongo@1.1.0
 observe-sequence@1.0.6
 ordered-dict@1.0.3
-ostrio:files@1.2.4
+ostrio:files@1.2.5
 ostrio:jsextensions@0.0.4
 random@1.0.3
 reactive-dict@1.1.0

--- a/files.coffee
+++ b/files.coffee
@@ -287,6 +287,12 @@ class Meteor.Files
       meta:       opts.meta
       type:       if opts.type then opts.type else 'application/*'
       size:       if opts.size then opts.size else buffer.length
+      versions:
+        original:
+          path: path
+          size: if opts.size then opts.size else buffer.length
+          type: if opts.type then opts.type else 'application/*'
+          extension: extension
       isVideo:    if opts.type then opts.type.toLowerCase().indexOf("video") > -1 else false
       isAudio:    if opts.type then opts.type.toLowerCase().indexOf("audio") > -1 else false
       isImage:    if opts.type then opts.type.toLowerCase().indexOf("image") > -1 else false

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'ostrio:files',
-  version: '1.2.4',
+  version: '1.2.5',
   summary: 'Upload, Store and Download small and huge files to/from file system (FS) via DDP and HTTP',
   git: 'https://github.com/VeliovGroup/Meteor-Files',
   documentation: 'README.md'


### PR DESCRIPTION
- Fix `Error: Versions is required` error, while calling `write()`
server method