### PR TITLE
Added reactive state property to the upload instance object returned by files.insert()

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,11 @@ Returns {*Object*}, with properties:
  - `continue` {*Function*} - Continue paused upload process
  - `toggleUpload` {*Function*} - Toggle `continue`/`pause` if upload in the progress
  - `abort` {*Function*} - Abort upload progress, and trigger `onAbort` callback
+ - `state` {*ReactiveVar*} - String reflecting current state of the upload, with four possible values:
+    * `active` - file is currently actively uploading
+    * `paused` - file upload is paused
+    * `aborted` - file upload has been aborted and can no longer be completed
+    * `completed` - file has been successfully uploaded
 
 ```coffeescript
 # For example we upload file for blog post

--- a/files.coffee
+++ b/files.coffee
@@ -781,8 +781,10 @@ class Meteor.Files
           continueFrom: []
           pause: () ->
             @onPause.set true
+            @state.set "paused"
           continue: () ->
             @onPause.set false
+            @state.set "active"
             func.call null for func in @continueFrom
             @continueFrom = []
           toggle: () ->
@@ -792,8 +794,10 @@ class Meteor.Files
             window.removeEventListener "beforeunload", beforeunload, false
             onAbort and onAbort.call file, fileData
             @pause()
+            @state.set "aborted"
             Meteor.call self.methodNames.MeteorFileAbort, randFileName, streams, file
             delete upload
+          state: new ReactiveVar "active"
 
         result.progress.set = _.throttle result.progress.set, 250
 
@@ -844,6 +848,8 @@ class Meteor.Files
           console.timeEnd('insert') if self.debug
           window.removeEventListener "beforeunload", beforeunload, false
           result.progress.set 0
+          if !error
+            result.state.set "completed"
           onUploaded and onUploaded.call self, error, data
 
         if onBeforeUpload and _.isFunction onBeforeUpload

--- a/files.coffee
+++ b/files.coffee
@@ -848,8 +848,7 @@ class Meteor.Files
           console.timeEnd('insert') if self.debug
           window.removeEventListener "beforeunload", beforeunload, false
           result.progress.set 0
-          if !error
-            result.state.set "completed"
+          result.state.set if error then "aborted" else "completed"
           onUploaded and onUploaded.call self, error, data
 
         if onBeforeUpload and _.isFunction onBeforeUpload


### PR DESCRIPTION
New feature satisfying my feature request: #56 

Like the title states, this adds a reactive state variable to the [upload instance object](https://github.com/VeliovGroup/Meteor-Files#insertsettings-client) returned by files.insert().  

It has four states:
* active - file is currently actively uploading
* paused - file upload is paused
* aborted - file upload has been aborted and can no longer be completed
* completed - file has been successfully uploaded

This is useful in easily maintaining consistent state, rather than having to infer it from a variety of factors.

I have not meddled in the existing `onPause` state variable, however `state` renders it redundant.  @dr-dimitru may want to update the package to replace `onPause` with `state` if this request is accepted.