### PR TITLE
fix: send meta Object with first chunk  dev

### DIFF
--- a/files.coffee
+++ b/files.coffee
@@ -347,6 +347,19 @@ class FilesCollection
         opts.binData ?= 'EOF'
         opts.chunkId ?= -1
 
+        console.info "[FilesCollection] [Write Method] Got ##{opts.chunkId}/#{opts.fileLength} chunks, dst: #{opts.file.name or opts.file.fileName}" if self.debug
+
+        if self.onBeforeUpload and _.isFunction self.onBeforeUpload
+          isUploadAllowed = self.onBeforeUpload.call(_.extend({
+            file: opts.file
+          }, {
+            userId: @userId, 
+            user: -> if Meteor.users then Meteor.users.findOne(@userId) else undefined
+          }), opts.file)
+
+          if isUploadAllowed isnt true
+            throw new Meteor.Error(403, if _.isString(isUploadAllowed) then isUploadAllowed else '@onBeforeUpload() returned false')
+
         fileName = self.getFileName opts.file
         {extension, extensionWithDot} = self.getExt fileName
 
@@ -358,19 +371,6 @@ class FilesCollection
         result           = self.dataToSchema result
         result._id       = opts.fileId
         result.userId    = @userId if @userId
-
-        console.info "[FilesCollection] [Write Method] Got ##{opts.chunkId}/#{opts.fileLength} chunks, dst: #{opts.file.name or opts.file.fileName}" if self.debug
-
-        if self.onBeforeUpload and _.isFunction self.onBeforeUpload
-          isUploadAllowed = self.onBeforeUpload.call(_.extend({
-            file: opts.file
-          }, {
-            userId: @userId, 
-            user: -> if Meteor.users then Meteor.users.findOne(@userId) else undefined
-          }), result)
-
-          if isUploadAllowed isnt true
-            throw new Meteor.Error(403, if _.isString(isUploadAllowed) then isUploadAllowed else '@onBeforeUpload() returned false')
 
         if opts.eof
           try
@@ -919,7 +919,6 @@ class FilesCollection
           size: @config.file.size
           type: @config.file.type
           name: @config.file.name
-          meta: @config.meta
 
         @fileData = _.extend @fileData, @collection.getExt(self.config.file.name), {mime: @collection.getMimeType(@fileData)}
         @fileData['mime-type'] = @fileData.mime

--- a/files.coffee
+++ b/files.coffee
@@ -354,7 +354,9 @@ class FilesCollection
             file: opts.file
           }, {
             userId: @userId, 
-            user: -> if Meteor.users then Meteor.users.findOne(@userId) else undefined
+            user: -> if Meteor.users then Meteor.users.findOne(@userId) else undefined,
+            meta: if opts.chunkId <= 1 then opts.meta else null,
+            chunkId: opts.chunkId
           }), opts.file)
 
           if isUploadAllowed isnt true
@@ -988,8 +990,7 @@ class FilesCollection
         chunkId:    evt.data.chunkId
         chunkSize:  @config.chunkSize
         fileLength: @fileLength
-
-      opts.meta = @config.meta if @sentChunks is 0 and evt.data.chunkId is 1
+        meta:       @config.meta
 
       @emitEvent 'data', [evt.data.bin]
       if @pipes.length

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'ostrio:files',
-  version: '1.5.3',
+  version: '1.5.4',
   summary: 'Fast and robust file uploads and streaming (Audio & Video), support FS or AWS, DropBox, Google Drive',
   git: 'https://github.com/VeliovGroup/Meteor-Files',
   documentation: 'README.md'

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'ostrio:files',
-  version: '1.5.4',
+  version: '1.5.3',
   summary: 'Fast and robust file uploads and streaming (Audio & Video), support FS or AWS, DropBox, Google Drive',
   git: 'https://github.com/VeliovGroup/Meteor-Files',
   documentation: 'README.md'


### PR DESCRIPTION
This solves https://github.com/VeliovGroup/Meteor-Files/issues/79

Reverted https://github.com/VeliovGroup/Meteor-Files/issues/79#issuecomment-220431951 because
https://github.com/VeliovGroup/Meteor-Files/issues/79#issuecomment-220531902 is the better approach.

This transmit the `chunkId` (to be able to determine if meta should have been set or not (Server)) and the `meta` object as well as part of each `onBeforeUpload` call. Both are accessible as context e.g. `this`.