### PR TITLE
add context.chunkId and context.eof to onBeforeUpload

### DIFF
--- a/docs/constructor.md
+++ b/docs/constructor.md
@@ -360,10 +360,10 @@
             <code>this.userId</code>
           </li>
           <li>
-            <code>this.chunkId</code> {<em>Number</em>}
+            <code>this.chunkId</code> {<em>Number</em>} - On <strong>server only</strong>
           </li>
           <li>
-            <code>this.eof</code> {<em>Boolean</em>}
+            <code>this.eof</code> {<em>Boolean</em>} - On <strong>server only</strong>
           </li>
         </ul>
       </td>
@@ -379,7 +379,7 @@
             <strong>return</strong> <code>false</code> to abort or {<em>String</em>} to abort upload with message
           </li>
         </ul>
-        <p><i>note: filedata.meta is always empty ({}) except on the first chunk (chunkId=1) and on eof (eof=true)</i></p>
+        <p><i>note: Because sending <code>meta</code> data as part of every chunk would hit the performance, <code>meta</code> is always empty ({}) except on the first chunk (chunkId=1) and on eof (eof=true)</i></p>
       </td>
     </tr>
     <tr>

--- a/docs/constructor.md
+++ b/docs/constructor.md
@@ -359,6 +359,12 @@
           <li>
             <code>this.userId</code>
           </li>
+          <li>
+            <code>this.chunkId</code> {<em>Number</em>}
+          </li>
+          <li>
+            <code>this.eof</code> {<em>Boolean</em>}
+          </li>
         </ul>
       </td>
       <td>
@@ -373,6 +379,7 @@
             <strong>return</strong> <code>false</code> to abort or {<em>String</em>} to abort upload with message
           </li>
         </ul>
+        <p><i>note: filedata.meta is always empty ({}) except on the first chunk (chunkId=1) and on eof (eof=true)</i></p>
       </td>
     </tr>
     <tr>

--- a/files.coffee
+++ b/files.coffee
@@ -366,7 +366,9 @@ class FilesCollection
             file: opts.file
           }, {
             userId: @userId, 
-            user: -> if Meteor.users then Meteor.users.findOne(@userId) else undefined
+            user: -> if Meteor.users then Meteor.users.findOne(@userId) else undefined,
+            chunkId: opts.chunkId,
+            eof: opts.eof
           }), result)
 
           if isUploadAllowed isnt true


### PR DESCRIPTION
This adds `chunkId` and `eof` as context for `onBeforeUpload` to help solving https://github.com/VeliovGroup/Meteor-Files/issues/79 

This is needed to determine if validation based on `meta` should fire. We need to know when to expect metadata since `meta`is transmitted on the first and last chunk only.