### PR TITLE
v1.6.5

### DIFF
--- a/.versions
+++ b/.versions
@@ -26,7 +26,7 @@ modules-runtime@0.6.5
 mongo-id@1.0.5
 observe-sequence@1.0.12
 ostrio:cookies@2.0.4
-ostrio:files@1.6.4
+ostrio:files@1.6.5
 promise@0.7.3
 random@1.0.10
 reactive-var@1.0.10

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ ToC:
  - [Why this package?](https://github.com/VeliovGroup/Meteor-Files#why-meteor-files)
  - [Installation](https://github.com/VeliovGroup/Meteor-Files#installation)
  - [ES6 Import](https://github.com/VeliovGroup/Meteor-Files#es6-import)
+ - [FAQ](https://github.com/VeliovGroup/Meteor-Files#faq)
  - [API](https://github.com/VeliovGroup/Meteor-Files#api-overview-full-api):
    * [Initialize Collection](https://github.com/VeliovGroup/Meteor-Files#new-filescollectionconfig-isomorphic)
    * [Upload file](https://github.com/VeliovGroup/Meteor-Files#insertsettings-autostart-client)
@@ -31,7 +32,6 @@ Files for Meteor
 
 Upload, Download, Serve and Stream files within your Meteor application. Without system dependencies, try [demo app](https://github.com/VeliovGroup/Meteor-Files#demo-application), which works smoothly on free/sandbox Heroku plan, [one click Heroku deploy](https://heroku.com/deploy?template=https://github.com/VeliovGroup/Meteor-Files-Demo)
 
-For current upload *pause/continue*, *speed*, *remaining time* and *progress* see *Object* returned from [`insert` method](https://github.com/VeliovGroup/Meteor-Files/wiki/Insert-(Upload)).
 
 Support:
 ========
@@ -85,6 +85,13 @@ ES6 Import:
 ```jsx
 import { FilesCollection } from 'meteor/ostrio:files';
 ```
+
+FAQ:
+========
+ 1. __Where files is stored by default?__: by default if `config.storagePath` isn't passed into [*Constructor*](https://github.com/VeliovGroup/Meteor-Files/wiki/Constructor) it's equals to `assets/app/uploads` and relative to running script:
+   * On `development` stage: `yourDevAppDir/.meteor/local/build/programs/server`, note: __all files will be removed as soon as your application will rebuild__ or you run `meteor reset`. To keep you storage persistent use absolute path *outside of your project folder*, we recommend to use `/data` directory
+   * On `production`: `yourProdAppDir/programs/server`
+ 2. __How to pause/continue upload and get progress/speed/remaining time?__: see *Object* returned from [`insert` method](https://github.com/VeliovGroup/Meteor-Files/wiki/Insert-(Upload))
 
 API overview (*[full API](https://github.com/VeliovGroup/Meteor-Files/wiki)*)
 ========

--- a/demo/.meteor/versions
+++ b/demo/.meteor/versions
@@ -67,7 +67,7 @@ mobile-experience@1.0.4
 mobile-status-bar@1.0.12
 modules@0.6.5
 modules-runtime@0.6.5
-momentjs:moment@2.14.1
+momentjs:moment@2.14.4
 mongo@1.1.9_1
 mongo-id@1.0.5
 mquandalle:jade@0.4.9
@@ -81,7 +81,7 @@ observe-sequence@1.0.12
 ordered-dict@1.0.8
 ostrio:cookies@2.0.4
 ostrio:cstorage@2.0.5
-ostrio:files@1.6.4
+ostrio:files@1.6.5
 ostrio:flow-router-extra@2.12.2
 ostrio:flow-router-meta@1.1.1
 ostrio:flow-router-title@2.1.1

--- a/demo/app.json
+++ b/demo/app.json
@@ -1,6 +1,6 @@
 {
   "name": "Meteor-Files-Demo",
-  "version": "1.6.2",
+  "version": "1.6.5",
   "description": "Demo application for ostrio:files package",
   "repository": "https://github.com/VeliovGroup/Meteor-Files-Demo",
   "website": "https://github.com/VeliovGroup/Meteor-Files-Demo",
@@ -19,6 +19,7 @@
     "meteor-deque": "*",
     "meteor-node-stubs": "~0.2.0",
     "meteor-promise": "0.7.2",
+    "promise": "7.1.1",
     "mime": "^1.3.4",
     "mongodb": "^2.1.15",
     "progress": "^1.1.8",
@@ -29,7 +30,7 @@
     "throttle": "1.0.3",
     "underscore": "1.5.2",
     "useragent": "^2.1.9",
-    "request": "2.72.0"
+    "request": "2.73.0"
   },
   "env": {
     "ROOT_URL": {
@@ -100,7 +101,7 @@
     }
   ],
   "engines": {
-    "node": "0.10.45",
-    "npm": "2.15.3"
+    "node": "0.10.46",
+    "npm": "3.10.5"
   }
 }

--- a/demo/client/file/file.coffee
+++ b/demo/client/file/file.coffee
@@ -1,16 +1,17 @@
 timer = false
 Template.file.onCreated ->
-  @fetchedText = new ReactiveVar false
-  @showPreview = new ReactiveVar false
-  @showInfo    = new ReactiveVar false
-  @warning     = new ReactiveVar false
+  @fetchedText  = new ReactiveVar false
+  @showOriginal = new ReactiveVar false
+  @showPreview  = new ReactiveVar false
+  @showInfo     = new ReactiveVar false
+  @warning      = new ReactiveVar false
   return
 
 Template.file.onRendered ->
   @warning.set false
   @fetchedText.set false
   if @data.file.isText or @data.file.isJSON
-    if  @data.file.size < 1024 * 64
+    if @data.file.size < 1024 * 64
       self = @
       HTTP.call 'GET', @data.file.link(), (error, resp) ->
         self.showPreview.set true
@@ -28,11 +29,18 @@ Template.file.onRendered ->
 
   else if @data.file.isImage
     self = @
-    img  = new Image()
-    img.onload = ->
-      self.showPreview.set true
-      return
-    img.src = @data.file.link 'preview'
+    if /png|jpe?g/i.test @data.type
+      img  = new Image()
+      img.onload = ->
+        self.showPreview.set true
+        return
+      img.src = @data.file.link 'preview'
+    else
+      img  = new Image()
+      img.onload = ->
+        self.showOriginal.set true
+        return
+      img.src = @data.file.link()
   window.IS_RENDERED = true
   return
 
@@ -42,6 +50,7 @@ Template.file.helpers
   isBlamed:    -> !!~_app.blamed.get().indexOf(@_id)
   showInfo:    -> Template.instance().showInfo.get()
   showPreview: -> Template.instance().showPreview.get()
+  showOriginal:-> Template.instance().showOriginal.get()
   fetchedText: -> Template.instance().fetchedText.get()
 
 Template.file.events

--- a/demo/client/file/file.jade
+++ b/demo/client/file/file.jade
@@ -39,9 +39,12 @@ template(name="file")
             link(itemprop="url" href="{{urlCurrent}}" content="{{urlCurrent}}")
             meta(itemprop="width" content="{{meta.width}}")
             meta(itemprop="height" content="{{meta.height}}")
-            source(type="#{type}" srcset="{{link 'preview'}}")
             if showPreview
+              source(type="#{type}" srcset="{{link 'preview'}}")
               img.file-preview(src="{{link 'preview'}}" alt="#{name}")
+            else if showOriginal
+              source(type="#{type}" srcset="{{link}}")
+              img.file-preview(src="{{link}}" alt="#{name}")
             else
               h1.files-note: i.fa.fa-fw.fa-spin.fa-spinner
         else if isAudio

--- a/demo/client/listing/listing-row.coffee
+++ b/demo/client/listing/listing-row.coffee
@@ -4,7 +4,7 @@ Template.listingRow.onCreated ->
   return
 
 Template.listingRow.onRendered ->
-  if @data.isImage
+  if @data.isImage and /png|jpe?g/i.test @data.type
     self = @
     img  = new Image()
     img.onload = ->

--- a/demo/lib/files.collection.coffee
+++ b/demo/lib/files.collection.coffee
@@ -278,6 +278,7 @@ if Meteor.isServer
         name: 1
         size: 1
         meta: 1
+        type: 1
         isPDF: 1
         isText: 1
         isJSON: 1

--- a/demo/package.json
+++ b/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Meteor-Files-Demo",
-  "version": "1.6.2",
+  "version": "1.6.5",
   "description": "Demo application for ostrio:files package",
   "main": "main.js",
   "scripts": {
@@ -40,6 +40,7 @@
     "meteor-deque": "*",
     "meteor-node-stubs": "~0.2.0",
     "meteor-promise": "0.7.2",
+    "promise": "7.1.1",
     "mime": "^1.3.4",
     "mongodb": "^2.1.15",
     "progress": "^1.1.8",
@@ -50,10 +51,10 @@
     "throttle": "1.0.3",
     "underscore": "1.5.2",
     "useragent": "^2.1.9",
-    "request": "2.72.0"
+    "request": "2.73.0"
   },
   "engines": {
-    "node": "0.10.45",
-    "npm": "2.15.3"
+    "node": "0.10.46",
+    "npm": "3.10.5"
   }
 }

--- a/docs/addFile.md
+++ b/docs/addFile.md
@@ -1,4 +1,4 @@
-##### `addFile(path [, opts, callback, onAfterUpload])` [*Server*]
+##### `addFile(path [, opts, callback, proceedAfterUpload])` [*Server*]
 
 *Add local file to FilesCollection from FS.*
 

--- a/docs/addFile.md
+++ b/docs/addFile.md
@@ -1,4 +1,4 @@
-##### `addFile(path [, opts, callback])` [*Server*]
+##### `addFile(path [, opts, callback, onAfterUpload])` [*Server*]
 
 *Add local file to FilesCollection from FS.*
 
@@ -11,6 +11,7 @@
    - `opts.type` {*String*} - Mime-type, like `image/png`
    - `opts.size` {*Number*} - File size in bytes, if not set - size will be calculated from file
  - `callback` {*Function*} - Triggered after new record is added to Collection. With `error`, and `fileRef`, where `fileRef` is a new record from DB
+ - proceedAfterUpload {*Boolean*} - Proceed `onAfterUpload` hook (*if defined*) after local file is added to `FilesCollection`
  - Returns {*FilesCollection*} - Current FilesCollection instance
 
 ```javascript

--- a/docs/load.md
+++ b/docs/load.md
@@ -1,4 +1,4 @@
-##### `load(url [, opts, callback, onAfterUpload])` [*Server*]
+##### `load(url [, opts, callback, proceedAfterUpload])` [*Server*]
 *Write file to FS from remote URL (external resource) and add record to FilesCollection*
 
  - `url` {*String*} - Full address to file, like `scheme://example.com/sample.png`

--- a/docs/load.md
+++ b/docs/load.md
@@ -1,4 +1,4 @@
-##### `load(url [, opts, callback])` [*Server*]
+##### `load(url [, opts, callback, onAfterUpload])` [*Server*]
 *Write file to FS from remote URL (external resource) and add record to FilesCollection*
 
  - `url` {*String*} - Full address to file, like `scheme://example.com/sample.png`
@@ -8,6 +8,7 @@
    - `opts.type` {*String*} - Mime-type, like `image/png`, if not set - mime-type will be taken from response headers
    - `opts.size` {*Number*} - File size in bytes, if not set - file size will be taken from response headers
  - `callback` {*Function*} - Triggered after first byte is received. With `error`, and `fileRef`, where `fileRef` is a new record from DB
+ - proceedAfterUpload {*Boolean*} - Proceed `onAfterUpload` hook (*if defined*) after external source is loaded to FS
  - Returns {*FilesCollection*} - Current FilesCollection instance
 
 ```javascript

--- a/docs/write.md
+++ b/docs/write.md
@@ -1,4 +1,4 @@
-##### `write(buffer [, opts, callback])` [*Server*]
+##### `write(buffer [, opts, callback, proceedAfterUpload])` [*Server*]
 
 Write `Buffer` to FS and add record to Files collection. This function is asynchronous.
 
@@ -9,6 +9,7 @@ Write `Buffer` to FS and add record to Files collection. This function is asynch
    - `opts.size` {*Number*} - File size in bytes, if not set file size will be calculated from `Buffer`
    - `opts.meta` {*Object*} - Object with custom meta-data
  - `callback` {*Function*} - Triggered after file is written to FS. With `error`, and `fileRef`, where `fileRef` is a new record from DB
+ - proceedAfterUpload {*Boolean*} - Proceed `onAfterUpload` hook (*if defined*) after `Buffer` is written to FS
  - Returns {*Files*} - Current FilesCollection instance
 
 ```javascript

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'ostrio:files',
-  version: '1.6.4',
+  version: '1.6.5',
   summary: 'Fast and robust file upload package, with support of FS, AWS, GridFS, DropBox or Google Drive',
   git: 'https://github.com/VeliovGroup/Meteor-Files',
   documentation: 'README.md'


### PR DESCRIPTION
 - Fix #148 - Proceed `onAfterUpload` hook in `.load()`, `.write()` and `.addFile()` methods within `proceedAfterUpload` flag
 - Add FAQ
 - Demo App: fix displaying images in other formats than `png` or `jpg`
 - Demo App: overall fixes