### PR TITLE
fix to get extension if link has query params after extension

### DIFF
--- a/files.coffee
+++ b/files.coffee
@@ -1082,7 +1082,7 @@ class FilesCollection
   ###
   _getExt: (fileName) ->
     if !!~fileName.indexOf('.')
-      extension = fileName.split('.').pop()
+      extension = fileName.split('.').pop().split('?')[0]
       return { ext: extension, extension, extensionWithDot: '.' + extension }
     else
       return { ext: '', extension: '', extensionWithDot: '' }


### PR DESCRIPTION
**Previous Behavior**
Previously getExt return the object with extension having any string after "."

**Now**
getExt will return ext in between '.' and '?' (so it trim the query params including question mark)

**Blocking Cause**
On Windows Special characters (which are found in query params '?' '&' ) are not allowed in file or folder naming convention therefore not allowing file stream to write. 

**Tested On**
Windows 10

This PR is raise again [this issue](https://github.com/VeliovGroup/Meteor-Files/issues/184)