### PR TITLE
v1.6.10

### DIFF
--- a/.versions
+++ b/.versions
@@ -38,7 +38,7 @@ npm-mongo@1.5.45
 observe-sequence@1.0.12
 ordered-dict@1.0.8
 ostrio:cookies@2.0.5
-ostrio:files@1.6.9
+ostrio:files@1.6.10
 promise@0.8.3
 random@1.0.10
 reactive-var@1.0.10

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Related Packages:
 Why `Meteor-Files`?
 ========
 The `cfs` is a well known package, but it's huge monster which combines everything. In `Meteor-Files` is nothing to broke, it's simply upload/store/serve files to/from server.
- - Support for both `HTTP` and `DDP` transports for upload
+ - Support for both `HTTP` and `DDP` transports for upload, [read about difference](https://github.com/VeliovGroup/Meteor-Files/wiki/About-Upload-Transports)
  - You need store to *[GridFS](https://github.com/VeliovGroup/Meteor-Files/wiki/GridFS-Integration)*, *[AWS S3](https://github.com/VeliovGroup/Meteor-Files/wiki/AWS-S3-Integration)*, *[Google Storage](https://github.com/VeliovGroup/Meteor-Files/wiki/Google-Cloud-Storage-Integration)* or *[DropBox](https://github.com/VeliovGroup/Meteor-Files/wiki/DropBox-Integration)*? (*[Use 3rd-party storage](https://github.com/VeliovGroup/Meteor-Files/wiki/Third-party-storage)*) - *Add it yourself*
  - You need to check file mime-type, size or extension? (*[`onBeforeUpload`](https://github.com/VeliovGroup/Meteor-Files/wiki/Constructor)*) - *Add it yourself*
  - You need to [resize images](https://github.com/VeliovGroup/Meteor-Files/blob/master/demo/server/image-processing.coffee) after upload? (*[`onAfterUpload`](https://github.com/VeliovGroup/Meteor-Files/wiki/Constructor)*, *[file's subversions](https://github.com/VeliovGroup/Meteor-Files/wiki/Create-and-Manage-Subversions)*) - *Add it yourself*
@@ -99,10 +99,10 @@ FAQ:
    * On `development` stage: `yourDevAppDir/.meteor/local/build/programs/server`, note: __all files will be removed as soon as your application will rebuild__ or you run `meteor reset`. To keep you storage persistent use absolute path *outside of your project folder*, we recommend to use `/data` directory
    * On `production`: `yourProdAppDir/programs/server`
  2. __How to pause/continue upload and get progress/speed/remaining time?__: see *Object* returned from [`insert` method](https://github.com/VeliovGroup/Meteor-Files/wiki/Insert-(Upload))
+ 3. When using any of `accounts` packages - package `accounts-base` must be explicitly added to `.meteor/packages` above `ostrio:files`
 
 API overview (*[full API](https://github.com/VeliovGroup/Meteor-Files/wiki)*)
 ========
-Note: When using any of `accounts` packages - package `accounts-base` must be explicitly added to `.meteor/packages` above `ostrio:files`
 
 #### `new FilesCollection([config])` [*Isomorphic*]
 Read full docs for [`FilesCollection` Constructor](https://github.com/VeliovGroup/Meteor-Files/wiki/Constructor)

--- a/docs/about-transports.md
+++ b/docs/about-transports.md
@@ -1,0 +1,35 @@
+### About upload Transports
+
+#### DDP (WebSockets)
+DDP (*Distributed Data Protocol*) build by MDG (*Meteor Dev Group*) on top of WebSockets via [SockJS](https://github.com/sockjs) library. DDP provides authentication, data standardization (*via EJSON*), and of course fallback to http, with long polling, if WebSockets is not available or not supported by browser.
+
+The pros:
+
+ - Persistent connection;
+ - Common way for Meteor to communicate with the server.
+
+The cons: 
+
+ - “magic” overhead inside DDP and EJSON;
+ - Only one data-transfer per time unit;
+ - It's synchronous.
+
+#### HTTP (TCP/IP)
+Well known way to exchange data between browser and server. To solve issue with opening connection and first-byte exchange use [HTTP/2](https://en.wikipedia.org/wiki/HTTP/2), [SSL/TLS](https://en.wikipedia.org/wiki/Transport_Layer_Security), SSL session cache and OCSP stapling.
+
+From [Is TLS Fast Yet](https://istlsfastyet.com/):
+> Unlike HTTP/1.1, HTTP/2 requires only a single connection per origin, which means fewer sockets, memory buffers, TLS handshakes, and so on.
+
+The pros:
+
+ - Asynchronous, unordered and simultaneous requests (*depends from browser, usually up to 10 simultaneous connections*);
+ - No data-processing/encoding, we send data as it is;
+ - Speed.
+
+The cons:
+
+ - HTTP (*Hypertext Transfer Protocol*) as you see from full name of the protocol it was initially created to transfer *hypertext*, other words HTML markup. So it was created for text-based data, not binary (*files*).
+
+
+#### RTC Data Chanel (UDP)
+*We're working on it*

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -18,7 +18,7 @@ Meteor-Files
 ### About:
  - Event-driven API
  - Upload / Read files in Cordova app: __Cordva support__ (Any with support of `FileReader`)
- - Upload via *HTTP* or *DDP*
+ - Upload via *HTTP* or *DDP*, [read about difference](https://github.com/VeliovGroup/Meteor-Files/wiki/About-Upload-Transports)
  - File upload:
     * Ready for small and large files (RAM used only for chunk reading - [read about `chunkSize`](https://github.com/VeliovGroup/Meteor-Files/wiki/Insert-(Upload)))
     * Pause / Resume upload

--- a/files.coffee
+++ b/files.coffee
@@ -1089,7 +1089,7 @@ class FilesCollection
   ###
   _getExt: (fileName) ->
     if !!~fileName.indexOf('.')
-      extension = fileName.split('.').pop().split('?')[0]
+      extension = (fileName.split('.').pop().split('?')[0] or '').toLowerCase()
       return { ext: extension, extension, extensionWithDot: '.' + extension }
     else
       return { ext: '', extension: '', extensionWithDot: '' }
@@ -1116,12 +1116,12 @@ class FilesCollection
           size: data.size
           type: data.type
           extension: data.extension
-      isVideo: !!~data.type.toLowerCase().indexOf('video')
-      isAudio: !!~data.type.toLowerCase().indexOf('audio')
-      isImage: !!~data.type.toLowerCase().indexOf('image')
-      isText:  !!~data.type.toLowerCase().indexOf('text')
-      isJSON:  !!~data.type.toLowerCase().indexOf('json')
-      isPDF:   !!~data.type.toLowerCase().indexOf('pdf')
+      isVideo: /^video\//i.test data.type
+      isAudio: /^audio\//i.test data.type
+      isImage: /^image\//i.test data.type
+      isText:  /^text\//i.test data.type
+      isJSON:  /application\/json/i.test data.type
+      isPDF:   /application\/pdf|application\/x-pdf/i.test data.type
       _storagePath:    data._storagePath or @storagePath
       _downloadRoute:  data._downloadRoute or @downloadRoute
       _collectionName: data._collectionName or @collectionName

--- a/files.coffee
+++ b/files.coffee
@@ -1478,7 +1478,7 @@ class FilesCollection
           console.time('loadFile ' + @config.file.name)
 
         if Worker and @config.allowWebWorkers
-          @worker = new Worker '/packages/ostrio_files/worker.js'
+          @worker = new Worker Meteor.absoluteUrl 'packages/ostrio_files/worker.js'
         else
           @worker = null
 

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'ostrio:files',
-  version: '1.6.9',
+  version: '1.6.10',
   summary: 'Fast and robust file upload package, with support of FS, AWS, GridFS, DropBox or Google Drive',
   git: 'https://github.com/VeliovGroup/Meteor-Files',
   documentation: 'README.md'

--- a/worker.js
+++ b/worker.js
@@ -1,6 +1,8 @@
+"use strict";
 self.onmessage = function(e) {
+  var fileReader;
   if (self.FileReader) {
-    var fileReader = new FileReader();
+    fileReader = new FileReader();
     fileReader.onloadend = function(chunk) {
       postMessage({bin: (fileReader.result || chunk.srcElement || chunk.target).split(',')[1], chunkId: e.data.currentChunk, start: e.data.start});
     };
@@ -12,7 +14,7 @@ self.onmessage = function(e) {
     fileReader.readAsDataURL(e.data.file.slice(e.data.chunkSize * (e.data.currentChunk - 1), e.data.chunkSize * e.data.currentChunk));
 
   } else if (self.FileReaderSync) {
-    var fileReader = new FileReaderSync();
+    fileReader = new FileReaderSync();
     postMessage({bin: fileReader.readAsDataURL(e.data.file.slice(e.data.chunkSize * (e.data.currentChunk - 1), e.data.chunkSize * e.data.currentChunk)).split(',')[1], chunkId: e.data.currentChunk, start: e.data.start});
 
   } else {


### PR DESCRIPTION
- Fix #183 (Use more certain mime-type check)
- Fix #186 (Merge #187, remove query-string from file's extension)
- Fix #188 (Use `Meteor.absoluteUrl` to get WebWorker)
- File extension now always is lowercase
- Avoid `JSON.stringify` and `JSON.parse` for HTTP uploads (*1.5x
upload speed improvement*)
- WebWorker: strict mode
- WebWorker: minor enhancements
- Overall optimization
- [DDP/HTTP upload difference
wiki](https://github.com/VeliovGroup/Meteor-Files/wiki/About-Upload-Tran
sports)