### PR TITLE
fix google doc for meteor env

### DIFF
--- a/docs/google-cloud-storage-integration.md
+++ b/docs/google-cloud-storage-integration.md
@@ -72,27 +72,29 @@ Collections.files = new FilesCollection({
       };
 
       bucket.upload(fileRef.path, options, function(error, file){
-        var upd;
-        if (error) {
-          console.error(error);
-        } else {
-          upd = {
-            $set: {}
-          };
-          upd['$set']["versions." + version + ".meta.pipeFrom"] = bucketMetadata.selfLink + '/' + filePath;
-          upd['$set']["versions." + version + ".meta.pipePath"] = filePath;
-          self.collection.update({
-            _id: fileRef._id
-          }, upd, function (error) {
-            if (error) {
-              console.error(error);
-            } else {
-              // Unlink original files from FS
-              // after successful upload to Google Cloud Storage
-              self.unlink(self.collection.findOne(fileRef._id), version);
-            }
-          });
-        }
+        bound(function(){
+          var upd;
+          if (error) {
+            console.error(error);
+          } else {
+            upd = {
+              $set: {}
+            };
+            upd['$set']["versions." + version + ".meta.pipeFrom"] = bucketMetadata.selfLink + '/' + filePath;
+            upd['$set']["versions." + version + ".meta.pipePath"] = filePath;
+            self.collection.update({
+              _id: fileRef._id
+            }, upd, function (error) {
+              if (error) {
+                console.error(error);
+              } else {
+                // Unlink original files from FS
+                // after successful upload to Google Cloud Storage
+                self.unlink(self.collection.findOne(fileRef._id), version);
+              }
+            });
+          }
+        });
       });
     });
   },


### PR DESCRIPTION
Meteor sync function
`self.unlink(self.collection.findOne(fileRef._id), version); `
is not working as expected, as it was not bounded by Meteor.bindEnvironment function.

due to this, after successful uploading files to google cloud storage, files were not deleting from local app storage.

PR is raise against [this issue](https://github.com/VeliovGroup/Meteor-Files/issues/217)