### PR TITLE
v1.7.11

### DIFF
--- a/.versions
+++ b/.versions
@@ -36,7 +36,7 @@ npm-mongo@1.5.45
 observe-sequence@1.0.12
 ordered-dict@1.0.8
 ostrio:cookies@2.1.3
-ostrio:files@1.7.10
+ostrio:files@1.7.11
 promise@0.8.3
 random@1.0.10
 reactive-var@1.0.10

--- a/files.coffee
+++ b/files.coffee
@@ -661,7 +661,7 @@ class FilesCollection
             self._currentUploads[doc._id].end()
 
             unless doc.isFinished
-              console.info "[FilesCollection] [_preCollectionCursor.observe] [removeUnfinishedUpload]: #{doc.file.path}" if self.debug
+              console.info "[FilesCollection] [_preCollectionCursor.observe] [removeUnfinishedUpload]: #{doc._id}" if self.debug
               self._currentUploads[doc._id].abort()
 
             delete self._currentUploads[doc._id]
@@ -799,8 +799,11 @@ class FilesCollection
                   if request.headers['x-eof'] is '1'
                     opts.eof = true
                   else
-                    if typeof Buffer.from == 'function'
-                      opts.binData = Buffer.from body, 'base64'
+                    if typeof Buffer.from is 'function'
+                      try
+                        opts.binData = Buffer.from body, 'base64'
+                      catch e
+                        opts.binData = new Buffer body, 'base64'
                     else
                       opts.binData = new Buffer body, 'base64'
                     opts.chunkId = parseInt request.headers['x-chunkid']
@@ -977,8 +980,11 @@ class FilesCollection
         }
 
         if opts.binData
-          if typeof Buffer.from == 'function'
-            opts.binData = Buffer.from opts.binData, 'base64'
+          if typeof Buffer.from is 'function'
+            try
+              opts.binData = Buffer.from opts.binData, 'base64'
+            catch e
+              opts.binData = new Buffer opts.binData, 'base64'
           else
             opts.binData = new Buffer opts.binData, 'base64'
 

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'ostrio:files',
-  version: '1.7.10',
+  version: '1.7.11',
   summary: 'Upload files via DDP, HTTP and WebRTC/DC. To server FS, AWS, GridFS, DropBox or Google Drive.',
   git: 'https://github.com/VeliovGroup/Meteor-Files',
   documentation: 'README.md'


### PR DESCRIPTION
 - Fix #355 - `Buffer.from` has no support of `base64` in some versions of node.js, while `Buffer.from` suggested replacement for deprecated `new Buffer()` constructor
 - Other minor fixes