### PR TITLE
Cors docs

### DIFF
--- a/docs/link.md
+++ b/docs/link.md
@@ -21,8 +21,6 @@ Images.findOne({}).link('thumbnail');
 var fileRef = Images.collection.findOne({});
 Images.link(fileRef, 'thumbnail');
 ```
-  
-  
 
 *Optional: Share link across different domain or subdomains*
 

--- a/docs/link.md
+++ b/docs/link.md
@@ -30,7 +30,7 @@ Optional: Share link across different domain or subdomains
 
 __[Server]__
 
-```
+```javascript
 /** Listen to incoming HTTP requests, can only be used on the server
  ** http://www.something.com/path/to/intercept
  **/

--- a/docs/link.md
+++ b/docs/link.md
@@ -21,3 +21,29 @@ Images.findOne({}).link('thumbnail');
 var fileRef = Images.collection.findOne({});
 Images.link(fileRef, 'thumbnail');
 ```
+
+
+Optional: Share link across different domain or subdomains
+
+[Cross-origin resource sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS):
+> A resource makes a cross-origin HTTP request when it requests a resource from a different domain, or port than the one which the first resource itself serves. For example, an HTML page served from http://domain-a.com makes an <img> src request for http://domain-b.com/image.jpg. Many pages on the web today load resources like CSS stylesheets, images and scripts from separate domains.
+
+__[Server]__
+
+```
+/** Listen to incoming HTTP requests, can only be used on the server
+ ** http://www.something.com/path/to/intercept
+ **/
+WebApp.rawConnectHandlers.use("/path/to/intercept", function(req, res, next) {
+  //define white list of urls, or can be done like adding subdomain as prefix to Meteor.absoluteUrl();
+  let whiteList = [];
+  const found = _.find(whiteList, function(url) {
+    return url == req.headers.origin;
+  });
+  if(found){
+    res.setHeader("Access-Control-Allow-Origin", req.headers.origin);
+  }
+  return next();
+});
+```
+

--- a/docs/link.md
+++ b/docs/link.md
@@ -21,9 +21,10 @@ Images.findOne({}).link('thumbnail');
 var fileRef = Images.collection.findOne({});
 Images.link(fileRef, 'thumbnail');
 ```
+  
+  
 
-
-Optional: Share link across different domain or subdomains
+*Optional: Share link across different domain or subdomains*
 
 [Cross-origin resource sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS):
 > A resource makes a cross-origin HTTP request when it requests a resource from a different domain, or port than the one which the first resource itself serves. For example, an HTML page served from http://domain-a.com makes an <img> src request for http://domain-b.com/image.jpg. Many pages on the web today load resources like CSS stylesheets, images and scripts from separate domains.


### PR DESCRIPTION
**WHY:**
Usually when surfing files to different domains, user browser faces cross domain issue

**CHANGES:**
Update link.md doc related to fix for cross domain issue, which states to compare origin with white list of domain and add the domain to headers of response if matched.
          