### PR TITLE
Dev - Documentation added For Collection Instances

### DIFF
--- a/docs/collection-instances.md
+++ b/docs/collection-instances.md
@@ -1,0 +1,70 @@
+##### `FilesCollection Instances and Mongo Collection Instances`
+
+While FilesCollection has a direct reference to a [`Mongo.Collection`](http://docs.meteor.com/#/full/mongo_collection),
+the Mongo.Collection has a back-reference to the FilesCollection itself.
+ 
+The reference chain is as the following:
+
+```javascript
+var Images = new FilesCollection({collectionName: 'Images'});
+
+// get the underlying Mongo.Collection
+var collection = Images.collection;
+
+// get the 'parent' FilesCollection 
+// of this collection instance
+var parent = collection.filesCollection;
+
+// returns true
+console.log(parent === Images);
+```
+
+
+##### Using dburles:mongo-collection-instances
+
+In Meteor you can use a Mongo.Collection instances management, such as [dburles:mongo-collection-instances](https://github.com/dburles/mongo-collection-instances).
+It allows you to retrieve Mongo.Collection instances by name in any module or file.
+
+**Note:** This package comes with no dependency to dburles:mongo-collection-instances. 
+If you want to make use of it, you need to install it to your meteor project first.
+
+```bash
+meteor add dburles:mongo-collection-instances
+```
+
+You can then instantiate your FilesCollection, which itself creates a new Mongo.Collection, that is now automatically added
+to a hidden Mongo.Collection instances list.
+
+```javascript
+var Images = new FilesCollection({collectionName: 'Images'}); 
+````
+
+You can retrieve your FilesCollection now anywhere using Mongo.Collection.get 
+
+```javascript
+var ImagesCollection = Mongo.Collection.get('Images');
+var Images = ImagesCollection.filesCollection;
+```` 
+
+##### Using a custom collection instance management
+
+This simplified example shows you, how to make use of that technique in your own implementation.
+Assume you have a map of all your Mongo.Collection instances:
+ 
+ ```javascript
+ var collectionsMap = {}; 
+ ````
+ 
+Since you don't want to store the FilesCollection (because it is no Mongo.Collection),
+you can still reference the underlying Mongo.Collection:
+
+```javascript
+var Images = new FilesCollection({collectionName: 'Images'});
+collectionsMap['Images'] = Images.collection;
+````
+
+Having your collection instances available, you can access the FilesCollection by reference:
+
+```javascript
+var Images = collectionsMap['Images'].filesCollection;
+````

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -95,7 +95,7 @@ Please see our experimental [webrtc-data-channel](https://github.com/VeliovGroup
  - [`link()`](https://github.com/VeliovGroup/Meteor-Files/wiki/link) [*Isomorphic*] - Generate downloadable link
  - [`collection`](https://github.com/VeliovGroup/Meteor-Files/wiki/collection) [*Isomorphic*] - `Meteor.Collection` instance
  - [Template helper `fileURL`](https://github.com/VeliovGroup/Meteor-Files/wiki/Template-Helper) [*Client*] - Generate downloadable link in a template
-
+ 
 ##### Examples:
  - [MUP/Docker Persistent Storage](https://github.com/VeliovGroup/Meteor-Files/wiki/MeteorUp-(MUP)-Usage) - Deploy via MeteorUp to Docker container with persistent `storagePath`
  - [Third-party storage (AWS S3, DropBox, GridFS and Google Storage)](https://github.com/VeliovGroup/Meteor-Files/wiki/Third-party-storage)
@@ -105,6 +105,7 @@ Please see our experimental [webrtc-data-channel](https://github.com/VeliovGroup
  - [File subversions](https://github.com/VeliovGroup/Meteor-Files/wiki/Create-and-Manage-Subversions) - Create video file with preview and multiple formats
  - [React - Example](https://github.com/VeliovGroup/Meteor-Files/wiki/React-Example) - React with a progress bar and component with links to view, re-name, and delete the files
  - [Converting from CollectionFS/CFS](https://github.com/VeliovGroup/Meteor-Files/wiki/Converting-from-CollectionFS) - Live conversion from the depreciated CFS to Meteor-Files (*Amazon S3 specifically, but applies to all*)
+ - [Get FilesCollection instance](https://github.com/VeliovGroup/Meteor-Files/wiki/collection-instances) - Retrieve the FilesCollection by it's underlying Mongo.Collection instance
 
 ##### Related Packages:
  - [pyfiles (meteor-python-files))](https://github.com/VeliovGroup/meteor-python-files) Python Client for Meteor-Files package


### PR DESCRIPTION
**Assumptions**

I assumed the attribute name of the reference to be `filesCollection` which makes the most sense in terms of self descriptiveness.

**Contribution**

 - Added a general description of the reference chain
 - Added a description for the use case with dburles:mongo-collection-instances
 - Added a description for the use case with a custom instance map