### PR TITLE
Update server.coffee

### DIFF
--- a/server.coffee
+++ b/server.coffee
@@ -990,7 +990,8 @@ class FilesCollection
   ###
   remove: (selector, callback) ->
     @_debug "[FilesCollection] [remove(#{JSON.stringify(selector)})]"
-    check selector, Match.OneOf Object, String
+    if !Match.test(selector, Match.OneOf(String, Object))
+      return 0
     check callback, Match.Optional Function
 
     files = @collection.find selector

--- a/server.coffee
+++ b/server.coffee
@@ -990,8 +990,8 @@ class FilesCollection
   ###
   remove: (selector, callback) ->
     @_debug "[FilesCollection] [remove(#{JSON.stringify(selector)})]"
-    if !Match.test(selector, Match.OneOf(String, Object))
-      return 0
+    if selector is undefined
+      return 0;
     check callback, Match.Optional Function
 
     files = @collection.find selector

--- a/server.coffee
+++ b/server.coffee
@@ -988,7 +988,7 @@ class FilesCollection
   @summary Remove documents from the collection
   @returns {FilesCollection} Instance
   ###
-  remove: (selector = {}, callback) ->
+  remove: (selector, callback) ->
     @_debug "[FilesCollection] [remove(#{JSON.stringify(selector)})]"
     check selector, Match.OneOf Object, String
     check callback, Match.Optional Function


### PR DESCRIPTION
if a undefined value is passed to remove, the whole FilesCollection will be removed because coffeescript to set a default value compare the argument passed to the function with '== null' to set the argument to {}
I think the solution is to delete the default value and let the check fail if the argument is not a string or a object
