### PR TITLE
Fix validation errors when using `FilesCollection.schema` on a document

### DIFF
--- a/core.js
+++ b/core.js
@@ -10,6 +10,9 @@ export default class FilesCollectionCore extends EventEmitter {
   }
 
   static schema = {
+    _id: {
+      type: String
+    },
     size: {
       type: Number
     },
@@ -43,6 +46,20 @@ export default class FilesCollectionCore extends EventEmitter {
     extension: {
       type: String,
       optional: true
+    },
+    ext: {
+      type: String,
+      optional: true
+    },
+    extensionWithDot: {
+      type: String,
+      optional: true
+    },
+    mime: {
+      type: String,
+    },
+    'mime-type': {
+      type: String,
     },
     _storagePath: {
       type: String

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -6,6 +6,9 @@ For more info see [Collection2](https://github.com/aldeed/meteor-collection2) an
 
 ```javascript
 var defaultSchema = {
+  _id: {
+    type: String
+  },
   size: {
     type: Number
   },
@@ -39,6 +42,20 @@ var defaultSchema = {
   extension: {
     type: String,
     optional: true
+  },
+  ext: {
+    type: String,
+    optional: true
+  },
+  extensionWithDot: {
+    type: String,
+    optional: true
+  },
+  mime: {
+    type: String,
+  },
+  'mime-type': {
+    type: String,
   },
   _storagePath: {
     type: String


### PR DESCRIPTION
I've found that validation fails on a document returned from a `FilesCollection` using the static schema because it's missing a few keys (`_id`, `ext`, `extenstionWithDot`, `mime`, `mime-type`)

Picked it up when directly importing my merged schema for validation of docs passed into a template. Confirmed it using `FilesCollection.schema` directly too.

This PR adds those missing keys to `FilesCollection.schema`