### PR TITLE
Allow fileId to be manualy dfined in insert method

### DIFF
--- a/upload.js
+++ b/upload.js
@@ -60,6 +60,7 @@ export class UploadInstance extends EventEmitter {
     check(this.config, {
       ddp: Match.Any,
       file: Match.Any,
+      fileId: Match.Optional(String),
       meta: Match.Optional(Object),
       type: Match.Optional(String),
       onError: Match.Optional(Function),
@@ -151,7 +152,7 @@ export class UploadInstance extends EventEmitter {
       this.sentChunks    = 0;
       this.fileLength    = 1;
       this.EOFsent       = false;
-      this.fileId        = Random.id();
+      this.fileId        = this.config.fileId || Random.id();
       this.FSName        = this.collection.namingFunction ? this.collection.namingFunction(this.fileData) : this.fileId;
       this.pipes         = [];
 


### PR DESCRIPTION
Hello.

Like any other collection in Meteor, we wanted to allow user to set the fileId ( _id ) manually or not at insert.

Cheers