### PR TITLE
Fix #579 - make mime optional in schema and fix _dataToSchema to include mime

### DIFF
--- a/core.js
+++ b/core.js
@@ -57,9 +57,11 @@ export default class FilesCollectionCore extends EventEmitter {
     },
     mime: {
       type: String,
+      optional: true
     },
     'mime-type': {
       type: String,
+      optional: true
     },
     _storagePath: {
       type: String
@@ -166,9 +168,13 @@ export default class FilesCollectionCore extends EventEmitter {
     const ds = {
       name: data.name,
       extension: data.extension,
+      ext: data.extension,
+      extensionWithDot: '.' + data.extension,
       path: data.path,
       meta: data.meta,
       type: data.type,
+      mime: data.type,
+      'mime-type': data.type,
       size: data.size,
       userId: data.userId || null,
       versions: {

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -53,9 +53,11 @@ var defaultSchema = {
   },
   mime: {
     type: String,
+    optional: true
   },
   'mime-type': {
     type: String,
+    optional: true
   },
   _storagePath: {
     type: String


### PR DESCRIPTION
 Fix #579 - Make `mime` optional in schema and fix `_dataToSchema` to include `mime`

@dr-dimitru Is `type` and `mime` always the same? Can I make the assumption that we can just set `mime` to `type`?