### PR TITLE
add sentChunks and fileLength information to emitted 'progress' event

### DIFF
--- a/upload.js
+++ b/upload.js
@@ -269,7 +269,7 @@ export class UploadInstance extends EventEmitter {
         const progress = Math.round((this.sentChunks / this.fileLength) * 100);
         this.result.progress.set(progress);
         this.config.onProgress && this.config.onProgress.call(this.result, progress, this.fileData);
-        this.result.emit('progress', progress, this.fileData);
+        this.result.emit('progress', progress, this.fileData, { sentChunks: this.sentChunks, fileLength: this.fileLength });
       }, 250));
 
       this.addListener('_onEnd', () => {


### PR DESCRIPTION
This PR adds additional information to the emitted `progress` event without altering the previous behaviour. EventDispatcher's `emit` can receive arbitrary parameters, which is why at the end of this event an additional Object with information about `sentChunks` and `fileLength` has been added.

This has been previously discussed in #704 