### PR TITLE
Progress info upgrade #704, abort event fix #706

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+# These are supported funding model platforms
+
+patreon: dr_dimitru
+custom: https://paypal.me/veliovgroup

--- a/upload.js
+++ b/upload.js
@@ -267,7 +267,13 @@ export class UploadInstance extends EventEmitter {
         this.result.estimateSpeed.set((this.config.chunkSize / (_t / 1000)));
 
         const progress = Math.round((this.sentChunks / this.fileLength) * 100);
-        const sentBytes = this.config.chunkSize * this.sentChunks;
+        let sentBytes = this.config.chunkSize * this.sentChunks;
+        if (sentBytes > this.fileData.size) {
+          // this case often occurs, when the last chunk
+          // is smaller than chunkSize, so we limit to fileSize
+          sentBytes = this.fileData.size;
+        }
+        
         this.result.progress.set(progress);
         this.config.onProgress && this.config.onProgress.call(this.result, progress, this.fileData);
         this.result.emit('progress', progress, this.fileData, { chunksSent: this.sentChunks, chunksLength: this.fileLength, bytesSent: sentBytes });

--- a/upload.js
+++ b/upload.js
@@ -30,6 +30,7 @@ export class FileUpload extends EventEmitter {
     this.state         = new ReactiveVar('active');
     this.onPause       = new ReactiveVar(false);
     this.progress      = new ReactiveVar(0);
+    this.sentChunks    = new ReactiveVar(0);
     this.continueFunc  = () => { };
     this.estimateTime  = new ReactiveVar(1000);
     this.estimateSpeed = new ReactiveVar(0);
@@ -70,11 +71,11 @@ export class FileUpload extends EventEmitter {
   abort() {
     this.config._debug('[FilesCollection] [insert] [.abort()]');
     window.removeEventListener('beforeunload', this.config.beforeunload, false);
-    this.config.onAbort && this.config.onAbort.call(this, this.file);
-    this.emit('abort', this.file);
     this.pause();
     this.config._onEnd();
     this.state.set('aborted');
+    this.config.onAbort && this.config.onAbort.call(this, this.file);
+    this.emit('abort', this.file);
     if (this.config.debug) {
       console.timeEnd(`insert ${this.config.fileData.name}`);
     }
@@ -268,8 +269,9 @@ export class UploadInstance extends EventEmitter {
 
         const progress = Math.round((this.sentChunks / this.fileLength) * 100);
         this.result.progress.set(progress);
+        this.result.sentChunks.set(this.sentChunks);
         this.config.onProgress && this.config.onProgress.call(this.result, progress, this.fileData);
-        this.result.emit('progress', progress, this.fileData);
+        this.result.emit('progress', progress, this.fileData, { sentChunks: this.sentChunks, maxChunks: this.fileLength });
       }, 250));
 
       this.addListener('_onEnd', () => {

--- a/upload.js
+++ b/upload.js
@@ -30,7 +30,6 @@ export class FileUpload extends EventEmitter {
     this.state         = new ReactiveVar('active');
     this.onPause       = new ReactiveVar(false);
     this.progress      = new ReactiveVar(0);
-    this.sentChunks    = new ReactiveVar(0);
     this.continueFunc  = () => { };
     this.estimateTime  = new ReactiveVar(1000);
     this.estimateSpeed = new ReactiveVar(0);
@@ -268,10 +267,10 @@ export class UploadInstance extends EventEmitter {
         this.result.estimateSpeed.set((this.config.chunkSize / (_t / 1000)));
 
         const progress = Math.round((this.sentChunks / this.fileLength) * 100);
+        const sentBytes = this.config.chunkSize * this.sentChunks;
         this.result.progress.set(progress);
-        this.result.sentChunks.set(this.sentChunks);
         this.config.onProgress && this.config.onProgress.call(this.result, progress, this.fileData);
-        this.result.emit('progress', progress, this.fileData, { sentChunks: this.sentChunks, maxChunks: this.fileLength });
+        this.result.emit('progress', progress, this.fileData, { chunksSent: this.sentChunks, chunksLength: this.fileLength, bytesSent: sentBytes });
       }, 250));
 
       this.addListener('_onEnd', () => {


### PR DESCRIPTION
On progress, there is now available raw info about count of sent chunks, which should provide more accurate calculation of progress, discussed in #704.

On abort was called before state `aborted` was set which led to bugs, so this is fixed. Discussed in #706.