### PR TITLE
When http.response is closed, close file stream with the close() function

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+# These are supported funding model platforms
+
+patreon: dr_dimitru
+custom: https://paypal.me/veliovgroup

--- a/server.js
+++ b/server.js
@@ -1690,6 +1690,9 @@ export class FilesCollection extends FilesCollectionCore {
         if (typeof stream.end === 'function') {
           stream.end();
         }
+        if (typeof stream.close === 'function') {
+          stream.close();
+        }
       });
 
       http.request.on('aborted', () => {


### PR DESCRIPTION
Hi!

Today's story is about a small company which uses Meteor-Files since a few years. One of its usage was to upload and stream video files. Quite simple you'd say...

One day, the small company received interest from an important TV channel whose video files were bigger than usual, thus causing the web browser to split the files into multiple parts.

In a normal world, all would have worked well but in this world the video couldn't be downloaded anymore after a few hours. Even worse, on the server-side it became impossible to read or remove the file: `[permission denied] Disk quota exceeded` ([Azure error and explanation](https://docs.microsoft.com/en-us/azure/storage/files/storage-troubleshoot-linux-file-connection-problems#permission-denied-disk-quota-exceeded-when-you-try-to-open-a-file)). 

"What the f*** 🤔?" said the devs. "Why is the file opened 2000 times simultaneously ? 😨"

After a lot of desperate tears because they were losing an important customer, the devs found out the impossible 😮. The bug wasn't coming from their own code, it was hidden in a library called Meteor-Files which never closed the file streams it opens with [`fs.createReadStream`](https://github.com/VeliovGroup/Meteor-Files/blob/50831583d56fdab7628c54391a4a68a9242ae74c/server.js#L1757). In fact, it turned out that the library was trying to call some [undocumented](https://nodejs.org/api/fs.html#fs_class_filehandle) `end()` and `abort()` functions which weren't existing too on the small company servers (seriously, where are they supposed to exist?).

After a few searches, the courageous devs, found out the way to beat this brutal bug. With the help of the legendary Node.JS documentation, [they modified the Meteor-Files code](https://github.com/VeliovGroup/Meteor-Files/compare/master...bbenoist:file-stream-close?expand=1#diff-78c12f5adc1848d13b1c6f07055d996eR1694) to make it call the `close()` function (when its available) at each time an HTTP stream ends.

After a long fight with the mighty meteor build process 🐌 , the devs were saved. The file streams were finally closed as in a normal world 🎉 

So, they made a PR and they lived together happily ever after. 

THE END

_Inspired by a true story lived by @bbenoist, @rolljee and @AntoineTohan_