### PR TITLE
Fix allow query string cookies

### DIFF
--- a/client.js
+++ b/client.js
@@ -8,7 +8,7 @@ import FilesCollectionCore from './core.js';
 import { formatFleURL, helpers } from './lib.js';
 
 const NOOP = () => { };
-const allowedParams = ['debug', 'ddp', 'schema', 'public', 'chunkSize', 'downloadRoute', 'collection', 'collectionName', 'namingFunction', 'onBeforeUpload', 'allowClientCode', 'onbeforeunloadMessage', 'disableUpload'];
+const allowedParams = ['debug', 'ddp', 'schema', 'public', 'chunkSize', 'downloadRoute', 'collection', 'collectionName', 'namingFunction', 'onBeforeUpload', 'allowClientCode', 'onbeforeunloadMessage', 'disableUpload', 'allowQueryStringCookies'];
 
 /*
  * @locus Anywhere
@@ -110,7 +110,7 @@ export class FilesCollection extends FilesCollectionCore {
     const setTokenCookie = () => {
       if (Meteor.connection._lastSessionId) {
         cookie.set('x_mtok', Meteor.connection._lastSessionId, { path: '/' });
-        if (Meteor.isCordova) {
+        if (Meteor.isCordova && this.allowQueryStringCookies) {
           cookie.send();
         }
       }

--- a/client.js
+++ b/client.js
@@ -110,6 +110,9 @@ export class FilesCollection extends FilesCollectionCore {
     const setTokenCookie = () => {
       if (Meteor.connection._lastSessionId) {
         cookie.set('x_mtok', Meteor.connection._lastSessionId, { path: '/' });
+        if (Meteor.isCordova) {
+          cookie.send();
+        }
       }
     };
 


### PR DESCRIPTION
@dr-dimitru 
My statement in https://github.com/VeliovGroup/Meteor-Files/issues/656#issuecomment-605661501 was wrong, I accidentally tested against the wrong branch, sorry for that. 🤦‍♂️

This PR fixes the following:

1. whitelists `allowQueryStringCookies`, otherwise it's just ignored.
2. `cookie.send();` is crucial here (and not obsolete), as this requests the server to set the cookie since just setting cookies on the client has no impact. This fulfills the reasoning around `allowQueryStringCookies`.

`cookie.send()` then results in 

![image](https://user-images.githubusercontent.com/4238881/79062839-d694b100-7c9d-11ea-8b63-9a786009ff67.png)

when `setTokenCookie` is called.