### PR TITLE
Fixes and improvements to typescript defs.

### DIFF
--- a/docs/typescript-definitions.md
+++ b/docs/typescript-definitions.md
@@ -2,7 +2,7 @@
 
 ```ts
 declare module "meteor/ostrio:files" {
-  import { Mongo } from 'meteor/mongo';
+	import { Mongo } from 'meteor/mongo';
   import { ReactiveVar } from 'meteor/reactive-var';
   import { SimpleSchemaDefinition } from 'simpl-schema';
   
@@ -16,37 +16,37 @@ declare module "meteor/ostrio:files" {
   }
 
 
-  class FileObj<MetadataType> {
+	class FileObj<MetadataType> {
     _id: string;
-    size: number;
-    name: string;
-    type: string;
-    path: string;
-    isVideo: boolean;
-    isAudio: boolean;
-    isImage: boolean;
-    isText: boolean;
-    isJSON: boolean;
-    isPDF: boolean;
+		size: number;
+		name: string;
+		type: string;
+		path: string;
+		isVideo: boolean;
+		isAudio: boolean;
+		isImage: boolean;
+		isText: boolean;
+		isJSON: boolean;
+		isPDF: boolean;
     ext?: string;
     extension?: string;
     extensionWithDot: string;
-    _storagePath: string;
-    _downloadRoute: string;
-    _collectionName: string;
-    public?: boolean;
-    meta?: MetadataType;
-    userId?: string;
-    updatedAt?: Date;
+		_storagePath: string;
+		_downloadRoute: string;
+		_collectionName: string;
+		public?: boolean;
+		meta?: MetadataType;
+		userId?: string;
+		updatedAt?: Date;
     versions: {
       [propName: string]: Version<MetadataType>;
     };
     mime: string;
     "mime-type": string;
-  }
+	}
 
 
-  type FileRef<MetadataType> = FileObj<MetadataType> & {
+	class FileRef<MetadataType> extends FileObj<MetadataType> {
     remove: (callback: (error: any) => void) => void;
     link: (version?: string, location?: string) => string;
     get: (property?: string) => FileObj<MetadataType> | any;
@@ -55,132 +55,126 @@ declare module "meteor/ostrio:files" {
   }
 
 
-  interface FileData<MetadataType> {
-    size: number;
-    type: string;
-    mime: string;
-    "mime-type": string;
-    ext: string;
-    extension: string;
+	interface FileData<MetadataType> {
+		size: number;
+		type: string;
+		mime: string;
+		"mime-type": string;
+		ext: string;
+		extension: string;
     name: string;
     meta: MetadataType;
-  }
+	}
 
 
-  interface FilesCollectionConfig<MetadataType> {
-    storagePath?: string | ((fileObj: FileObj<MetadataType>) => string);
-    collection?: Mongo.Collection<FileObj<MetadataType>>;
-    collectionName?: string;
-    continueUploadTTL?: string;
-    ddp?: Object;
-    cacheControl?: string;
-    responseHeaders?: { [x: string]: string } | ((responseCode?: string, fileRef?: FileRef<MetadataType>, versionRef?: Version<MetadataType>, version?: string) => { [x: string]: string });
-    throttle?: number | boolean;
-    downloadRoute?: string;
-    schema?: SimpleSchemaDefinition;
-    chunkSize?: number;
-    namingFunction?: (fileObj: FileObj<MetadataType>) => string;
-    permissions?: number;
-    parentDirPermissions?: number;
-    integrityCheck?: boolean;
-    strict?: boolean;
-    downloadCallback?: (fileObj: FileObj<MetadataType>) => boolean;
-    protected?: boolean | ((fileObj: FileObj<MetadataType>) => boolean | number);
-    public?: boolean;
-    onBeforeUpload?: (fileData: FileData<MetadataType>) => boolean | string;
-    onBeforeRemove?: (cursor: Mongo.Cursor<FileObj<MetadataType>>) => boolean;
-    onInitiateUpload?: (fileData: FileData<MetadataType>) => void;
-    onAfterUpload?: (fileRef: FileRef<MetadataType>) => any;
-    onAfterRemove?: (files: FileObj<MetadataType>[]) => any;
-    onbeforeunloadMessage?: string | (() => string);
-    allowClientCode?: boolean;
-    debug?: boolean;
-    interceptDownload?: (http: Object, fileRef: FileRef<MetadataType>, version: string) => boolean;
-  }
-  
-
-  export interface SearchOptions<MetadataType, TransformedType> {
-    sort?: Mongo.SortSpecifier;
-    skip?: number;
-    limit?: number;
-    fields?: Mongo.FieldSpecifier;
-    reactive?: boolean;
-    transform?: (fileObj: FileObj<MetadataType>) => FileObj<TransformedType>;
+	interface FilesCollectionConfig<MetadataType> {
+		storagePath?: string | ((fileObj: FileObj<MetadataType>) => string);
+		collection?: Mongo.Collection<FileObj<MetadataType>>;
+		collectionName?: string;
+		continueUploadTTL?: string;
+		ddp?: Object;
+		cacheControl?: string;
+		responseHeaders?: { [x: string]: string } | ((responseCode?: string, fileRef?: FileRef<MetadataType>, versionRef?: Version<MetadataType>, version?: string) => { [x: string]: string });
+		throttle?: number | boolean;
+		downloadRoute?: string;
+		schema?: SimpleSchemaDefinition;
+		chunkSize?: number;
+		namingFunction?: (fileObj: FileObj<MetadataType>) => string;
+		permissions?: number;
+		parentDirPermissions?: number;
+		integrityCheck?: boolean;
+		strict?: boolean;
+		downloadCallback?: (fileObj: FileObj<MetadataType>) => boolean;
+		protected?: boolean | ((fileObj: FileObj<MetadataType>) => boolean | number);
+		public?: boolean;
+		onBeforeUpload?: (fileData: FileData<MetadataType>) => boolean | string;
+		onBeforeRemove?: (cursor: Mongo.Cursor<FileObj<MetadataType>>) => boolean;
+		onInitiateUpload?: (fileData: FileData<MetadataType>) => void;
+		onAfterUpload?: (fileRef: FileRef<MetadataType>) => any;
+		onAfterRemove?: (files: FileObj<MetadataType>[]) => any;
+		onbeforeunloadMessage?: string | (() => string);
+		allowClientCode?: boolean;
+		debug?: boolean;
+		interceptDownload?: (http: Object, fileRef: FileRef<MetadataType>, version: string) => boolean;
   }
   
 
-  export interface InsertOptions<MetadataType> {
-    file: File | Object | string;
-    isBase64?: boolean;
-    meta?: MetadataType;
-    transport?: 'ddp' | 'http'
-    onStart?: (error: Object, fileData: FileData<MetadataType>) => any;
-    onUploaded?: (error: Object, fileRef: FileRef<MetadataType>) => any;
-    onAbort?: (fileData: FileData<MetadataType>) => any;
-    onError?: (error: Object, fileData: FileData<MetadataType>) => any;
-    onProgress?: (progress: number, fileData: FileData<MetadataType>) => any;
-    onBeforeUpload?: (fileData: FileData<MetadataType>) => any;
-    streams?: number | 'dynamic';
-    chunkSize?: number | 'dynamic';
-    allowWebWorkers?: boolean;
+	export interface SearchOptions<MetadataType, TransformAdditions> {
+		sort?: Mongo.SortSpecifier;
+		skip?: number;
+		limit?: number;
+		fields?: Mongo.FieldSpecifier;
+		reactive?: boolean;
+		transform?: (fileObj: FileObj<MetadataType>) => FileObj<MetadataType> & TransformAdditions;
   }
+  
+
+	export interface InsertOptions<MetadataType> {
+		file: File | Object | string;
+		isBase64?: boolean;
+		meta?: MetadataType;
+		transport?: 'ddp' | 'http'
+		onStart?: (error: Object, fileData: FileData<MetadataType>) => any;
+		onUploaded?: (error: Object, fileRef: FileRef<MetadataType>) => any;
+		onAbort?: (fileData: FileData<MetadataType>) => any;
+		onError?: (error: Object, fileData: FileData<MetadataType>) => any;
+		onProgress?: (progress: number, fileData: FileData<MetadataType>) => any;
+		onBeforeUpload?: (fileData: FileData<MetadataType>) => any;
+		streams?: number | 'dynamic';
+		chunkSize?: number | 'dynamic';
+		allowWebWorkers?: boolean;
+	}
 
 
-  export interface LoadOptions<MetadataType> {
-    fileName: string;
-    meta?: MetadataType;
-    type?: string;
-    size?: number;
-  }
+	export interface LoadOptions<MetadataType> {
+		fileName: string;
+		meta?: MetadataType;
+		type?: string;
+		size?: number;
+	}
 
 
-  export class FileUpload {
-    file: File;
-    onPause: ReactiveVar<boolean>;
-    progress: ReactiveVar<number>;
-    estimateTime: ReactiveVar<number>;
-    estimateSpeed: ReactiveVar<number>;
-    state: ReactiveVar<'active' | 'paused' | 'aborted' | 'completed'>;
+	export class FileUpload {
+		file: File;
+		onPause: ReactiveVar<boolean>;
+		progress: ReactiveVar<number>;
+		estimateTime: ReactiveVar<number>;
+		estimateSpeed: ReactiveVar<number>;
+		state: ReactiveVar<'active' | 'paused' | 'aborted' | 'completed'>;
 
-    pause();
-    continue();
-    toggle();
-    pipe();
-    start();
-    on(event: string, callback: Function): void;
-  }
-
-
-  export class FileCursor<MetadataType> extends FileObj<MetadataType> { // Is it correct to say that it extends FileObj?
-    remove(callback: (err) => void): void;
-    link(): string;
-    get(property: string): Object | any;
-    fetch(): Object[];
-    with(): ReactiveVar<FileCursor<MetadataType>>;
-  }
+		pause();
+		continue();
+		toggle();
+		pipe();
+		start();
+		on(event: string, callback: Function): void;
+	}
 
 
-  export class FilesCursor<MetadataType> extends Mongo.Cursor<FileObj<MetadataType>> {
-    cursor: Mongo.Cursor<FileObj<MetadataType>>; // Refers to base cursor? Why is this existing?
+	export class FileCursor<MetadataType> extends FileRef<MetadataType> { }
 
-    get(): Object[];
-    hasNext(): boolean;
-    next(): Object;
-    hasPrevious(): boolean;
-    previous(): Object;
-    first(): Object;
-    last(): Object;
-    remove(callback: (err) => void): void;
-    each(): FileCursor<MetadataType>[];
-    current(): Object | undefined;
-  }
+
+	export class FilesCursor<MetadataType, TransformAdditions> extends Mongo.Cursor<FileObj<MetadataType>> {
+		cursor: Mongo.Cursor<FileObj<MetadataType>>; // Refers to base cursor? Why is this existing?
+
+		get(): Array<FileCursor<MetadataType> & TransformAdditions>;
+		hasNext(): boolean;
+		next(): FileCursor<MetadataType> & TransformAdditions;
+		hasPrevious(): boolean;
+		previous(): FileCursor<MetadataType> & TransformAdditions;
+		first(): FileCursor<MetadataType> & TransformAdditions;
+		last(): FileCursor<MetadataType> & TransformAdditions;
+		remove(callback: (err: Object) => void): void;
+		each(): Array<FileCursor<MetadataType> & TransformAdditions>;
+		current(): Object | undefined;
+	}
 
 
   export class FilesCollection<MetadataType = { [x: string]: any }> {
-    collection: Mongo.Collection<FileObj<MetadataType>>;
-    schema: SimpleSchemaDefinition;
+		collection: Mongo.Collection<FileObj<MetadataType>>;
+		schema: SimpleSchemaDefinition;
 
-    constructor(config: FilesCollectionConfig<MetadataType>)
+		constructor(config: FilesCollectionConfig<MetadataType>)
 
     /**
      * Find and return Cursor for matching documents.
@@ -188,29 +182,35 @@ declare module "meteor/ostrio:files" {
      * @param selector [[http://docs.meteor.com/api/collections.html#selectors | Mongo-Style selector]]
      * @param options [[http://docs.meteor.com/api/collections.html#sortspecifiers | Mongo-Style selector Options]]
     
-     * @typeParam TransformedType The result of transforming a document with options.tranform().
+     * @template TransformAdditions Additional properties provided by transforming a document with options.tranform(). 
+     *            Note that removing fields with a transform function is not currently supported as this may break 
+     *            functions defined on a FileRef or FileCursor.
      */
-    find<TransformedType = FileRef<MetadataType>>(selector?: Mongo.Selector<Partial<FileObj<MetadataType>>>, options?: SearchOptions<MetadataType, TransformedType>): FilesCursor<TransformedType>;
+    find<TransformAdditions = {}>(selector?: Mongo.Selector<Partial<FileObj<MetadataType>>>, options?: SearchOptions<MetadataType, TransformAdditions>): FilesCursor<MetadataType, TransformAdditions>;
+    
     /**
      * Finds the first document that matches the selector, as ordered by sort and skip options.
      * 
      * @param selector [[http://docs.meteor.com/api/collections.html#selectors | Mongo-Style selector]]
      * @param options [[http://docs.meteor.com/api/collections.html#sortspecifiers | Mongo-Style selector Options]]
-    
-     * @typeParam TransformedType The result of transforming a document with options.tranform().
+     * 
+     * @template TransformAdditions Additional properties provided by transforming a document with options.tranform().
+     *            Note that removing fields with a transform function is not currently supported as this may break 
+     *            functions defined on a FileRef or FileCursor.
      */
-    findOne<TransformedType = FileRef<MetadataType>>(selector?: Mongo.Selector<Partial<FileObj<MetadataType>>> | string, options?: SearchOptions<MetadataType, TransformedType>): FileCursor<TransformedType>;
+    findOne<TransformAdditions = {}>(selector?: Mongo.Selector<Partial<FileObj<MetadataType>>> | string, options?: SearchOptions<MetadataType, TransformAdditions>): FileCursor<MetadataType> & TransformAdditions;
+    
     insert(settings: InsertOptions<MetadataType>, autoStart?: boolean): FileUpload;
-    remove(select: Mongo.Selector<FileObj<MetadataType>> | string, callback?: (error: Object) => Object): FilesCollection<MetadataType>;
-    link(fileRef: FileRef<MetadataType>, version?: string): string;
-    allow(options: Mongo.AllowDenyOptions): void;
-    deny(options: Mongo.AllowDenyOptions): void;
-    denyClient(): void;
-    on(event: string, callback: (fileRef: FileRef<MetadataType>) => void): void;
-    unlink(fileRef: FileRef<MetadataType>, version?: string): FilesCollection<MetadataType>;
-    addFile(path: string, opts: LoadOptions<MetadataType>, callback: (err: any, fileRef: FileRef<MetadataType>) => any, proceedAfterUpload: boolean): FilesCollection<MetadataType>;
-    load(url: string, opts: LoadOptions<MetadataType>, callback: (err: Object, fileRef: FileRef<MetadataType>) => any, proceedAfterUpload: boolean): FilesCollection<MetadataType>;
-    write(buffer: Buffer, opts: LoadOptions<MetadataType>, callback: (err: Object, fileRef: FileRef<MetadataType>) => any, proceedAfterUpload: boolean): FilesCollection<MetadataType>;
-  }
+		remove(select: Mongo.Selector<FileObj<MetadataType>> | string, callback?: (error: Object) => Object): FilesCollection<MetadataType>;
+		link(fileRef: FileRef<MetadataType>, version?: string): string;
+		allow(options: Mongo.AllowDenyOptions): void;
+		deny(options: Mongo.AllowDenyOptions): void;
+		denyClient(): void;
+		on(event: string, callback: (fileRef: FileRef<MetadataType>) => void): void;
+		unlink(fileRef: FileRef<MetadataType>, version?: string): FilesCollection<MetadataType>;
+		addFile(path: string, opts: LoadOptions<MetadataType>, callback: (err: any, fileRef: FileRef<MetadataType>) => any, proceedAfterUpload: boolean): FilesCollection<MetadataType>;
+		load(url: string, opts: LoadOptions<MetadataType>, callback: (err: Object, fileRef: FileRef<MetadataType>) => any, proceedAfterUpload: boolean): FilesCollection<MetadataType>;
+		write(buffer: Buffer, opts: LoadOptions<MetadataType>, callback: (err: Object, fileRef: FileRef<MetadataType>) => any, proceedAfterUpload: boolean): FilesCollection<MetadataType>;
+	}
 }
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 declare module "meteor/ostrio:files" {
-  import { Mongo } from 'meteor/mongo';
+	import { Mongo } from 'meteor/mongo';
   import { ReactiveVar } from 'meteor/reactive-var';
   import { SimpleSchemaDefinition } from 'simpl-schema';
   
@@ -13,37 +13,37 @@ declare module "meteor/ostrio:files" {
   }
 
 
-  class FileObj<MetadataType> {
+	class FileObj<MetadataType> {
     _id: string;
-    size: number;
-    name: string;
-    type: string;
-    path: string;
-    isVideo: boolean;
-    isAudio: boolean;
-    isImage: boolean;
-    isText: boolean;
-    isJSON: boolean;
-    isPDF: boolean;
+		size: number;
+		name: string;
+		type: string;
+		path: string;
+		isVideo: boolean;
+		isAudio: boolean;
+		isImage: boolean;
+		isText: boolean;
+		isJSON: boolean;
+		isPDF: boolean;
     ext?: string;
     extension?: string;
     extensionWithDot: string;
-    _storagePath: string;
-    _downloadRoute: string;
-    _collectionName: string;
-    public?: boolean;
-    meta?: MetadataType;
-    userId?: string;
-    updatedAt?: Date;
+		_storagePath: string;
+		_downloadRoute: string;
+		_collectionName: string;
+		public?: boolean;
+		meta?: MetadataType;
+		userId?: string;
+		updatedAt?: Date;
     versions: {
       [propName: string]: Version<MetadataType>;
     };
     mime: string;
     "mime-type": string;
-  }
+	}
 
 
-  type FileRef<MetadataType> = FileObj<MetadataType> & {
+	class FileRef<MetadataType> extends FileObj<MetadataType> {
     remove: (callback: (error: any) => void) => void;
     link: (version?: string, location?: string) => string;
     get: (property?: string) => FileObj<MetadataType> | any;
@@ -52,132 +52,126 @@ declare module "meteor/ostrio:files" {
   }
 
 
-  interface FileData<MetadataType> {
-    size: number;
-    type: string;
-    mime: string;
-    "mime-type": string;
-    ext: string;
-    extension: string;
+	interface FileData<MetadataType> {
+		size: number;
+		type: string;
+		mime: string;
+		"mime-type": string;
+		ext: string;
+		extension: string;
     name: string;
     meta: MetadataType;
-  }
+	}
 
 
-  interface FilesCollectionConfig<MetadataType> {
-    storagePath?: string | ((fileObj: FileObj<MetadataType>) => string);
-    collection?: Mongo.Collection<FileObj<MetadataType>>;
-    collectionName?: string;
-    continueUploadTTL?: string;
-    ddp?: Object;
-    cacheControl?: string;
-    responseHeaders?: { [x: string]: string } | ((responseCode?: string, fileRef?: FileRef<MetadataType>, versionRef?: Version<MetadataType>, version?: string) => { [x: string]: string });
-    throttle?: number | boolean;
-    downloadRoute?: string;
-    schema?: SimpleSchemaDefinition;
-    chunkSize?: number;
-    namingFunction?: (fileObj: FileObj<MetadataType>) => string;
-    permissions?: number;
-    parentDirPermissions?: number;
-    integrityCheck?: boolean;
-    strict?: boolean;
-    downloadCallback?: (fileObj: FileObj<MetadataType>) => boolean;
-    protected?: boolean | ((fileObj: FileObj<MetadataType>) => boolean | number);
-    public?: boolean;
-    onBeforeUpload?: (fileData: FileData<MetadataType>) => boolean | string;
-    onBeforeRemove?: (cursor: Mongo.Cursor<FileObj<MetadataType>>) => boolean;
-    onInitiateUpload?: (fileData: FileData<MetadataType>) => void;
-    onAfterUpload?: (fileRef: FileRef<MetadataType>) => any;
-    onAfterRemove?: (files: FileObj<MetadataType>[]) => any;
-    onbeforeunloadMessage?: string | (() => string);
-    allowClientCode?: boolean;
-    debug?: boolean;
-    interceptDownload?: (http: Object, fileRef: FileRef<MetadataType>, version: string) => boolean;
-  }
-  
-
-  export interface SearchOptions<MetadataType, TransformedType> {
-    sort?: Mongo.SortSpecifier;
-    skip?: number;
-    limit?: number;
-    fields?: Mongo.FieldSpecifier;
-    reactive?: boolean;
-    transform?: (fileObj: FileObj<MetadataType>) => FileObj<TransformedType>;
+	interface FilesCollectionConfig<MetadataType> {
+		storagePath?: string | ((fileObj: FileObj<MetadataType>) => string);
+		collection?: Mongo.Collection<FileObj<MetadataType>>;
+		collectionName?: string;
+		continueUploadTTL?: string;
+		ddp?: Object;
+		cacheControl?: string;
+		responseHeaders?: { [x: string]: string } | ((responseCode?: string, fileRef?: FileRef<MetadataType>, versionRef?: Version<MetadataType>, version?: string) => { [x: string]: string });
+		throttle?: number | boolean;
+		downloadRoute?: string;
+		schema?: SimpleSchemaDefinition;
+		chunkSize?: number;
+		namingFunction?: (fileObj: FileObj<MetadataType>) => string;
+		permissions?: number;
+		parentDirPermissions?: number;
+		integrityCheck?: boolean;
+		strict?: boolean;
+		downloadCallback?: (fileObj: FileObj<MetadataType>) => boolean;
+		protected?: boolean | ((fileObj: FileObj<MetadataType>) => boolean | number);
+		public?: boolean;
+		onBeforeUpload?: (fileData: FileData<MetadataType>) => boolean | string;
+		onBeforeRemove?: (cursor: Mongo.Cursor<FileObj<MetadataType>>) => boolean;
+		onInitiateUpload?: (fileData: FileData<MetadataType>) => void;
+		onAfterUpload?: (fileRef: FileRef<MetadataType>) => any;
+		onAfterRemove?: (files: FileObj<MetadataType>[]) => any;
+		onbeforeunloadMessage?: string | (() => string);
+		allowClientCode?: boolean;
+		debug?: boolean;
+		interceptDownload?: (http: Object, fileRef: FileRef<MetadataType>, version: string) => boolean;
   }
   
 
-  export interface InsertOptions<MetadataType> {
-    file: File | Object | string;
-    isBase64?: boolean;
-    meta?: MetadataType;
-    transport?: 'ddp' | 'http'
-    onStart?: (error: Object, fileData: FileData<MetadataType>) => any;
-    onUploaded?: (error: Object, fileRef: FileRef<MetadataType>) => any;
-    onAbort?: (fileData: FileData<MetadataType>) => any;
-    onError?: (error: Object, fileData: FileData<MetadataType>) => any;
-    onProgress?: (progress: number, fileData: FileData<MetadataType>) => any;
-    onBeforeUpload?: (fileData: FileData<MetadataType>) => any;
-    streams?: number | 'dynamic';
-    chunkSize?: number | 'dynamic';
-    allowWebWorkers?: boolean;
+	export interface SearchOptions<MetadataType, TransformAdditions> {
+		sort?: Mongo.SortSpecifier;
+		skip?: number;
+		limit?: number;
+		fields?: Mongo.FieldSpecifier;
+		reactive?: boolean;
+		transform?: (fileObj: FileObj<MetadataType>) => FileObj<MetadataType> & TransformAdditions;
   }
+  
+
+	export interface InsertOptions<MetadataType> {
+		file: File | Object | string;
+		isBase64?: boolean;
+		meta?: MetadataType;
+		transport?: 'ddp' | 'http'
+		onStart?: (error: Object, fileData: FileData<MetadataType>) => any;
+		onUploaded?: (error: Object, fileRef: FileRef<MetadataType>) => any;
+		onAbort?: (fileData: FileData<MetadataType>) => any;
+		onError?: (error: Object, fileData: FileData<MetadataType>) => any;
+		onProgress?: (progress: number, fileData: FileData<MetadataType>) => any;
+		onBeforeUpload?: (fileData: FileData<MetadataType>) => any;
+		streams?: number | 'dynamic';
+		chunkSize?: number | 'dynamic';
+		allowWebWorkers?: boolean;
+	}
 
 
-  export interface LoadOptions<MetadataType> {
-    fileName: string;
-    meta?: MetadataType;
-    type?: string;
-    size?: number;
-  }
+	export interface LoadOptions<MetadataType> {
+		fileName: string;
+		meta?: MetadataType;
+		type?: string;
+		size?: number;
+	}
 
 
-  export class FileUpload {
-    file: File;
-    onPause: ReactiveVar<boolean>;
-    progress: ReactiveVar<number>;
-    estimateTime: ReactiveVar<number>;
-    estimateSpeed: ReactiveVar<number>;
-    state: ReactiveVar<'active' | 'paused' | 'aborted' | 'completed'>;
+	export class FileUpload {
+		file: File;
+		onPause: ReactiveVar<boolean>;
+		progress: ReactiveVar<number>;
+		estimateTime: ReactiveVar<number>;
+		estimateSpeed: ReactiveVar<number>;
+		state: ReactiveVar<'active' | 'paused' | 'aborted' | 'completed'>;
 
-    pause();
-    continue();
-    toggle();
-    pipe();
-    start();
-    on(event: string, callback: Function): void;
-  }
-
-
-  export class FileCursor<MetadataType> extends FileObj<MetadataType> { // Is it correct to say that it extends FileObj?
-    remove(callback: (err) => void): void;
-    link(): string;
-    get(property: string): Object | any;
-    fetch(): Object[];
-    with(): ReactiveVar<FileCursor<MetadataType>>;
-  }
+		pause();
+		continue();
+		toggle();
+		pipe();
+		start();
+		on(event: string, callback: Function): void;
+	}
 
 
-  export class FilesCursor<MetadataType> extends Mongo.Cursor<FileObj<MetadataType>> {
-    cursor: Mongo.Cursor<FileObj<MetadataType>>; // Refers to base cursor? Why is this existing?
+	export class FileCursor<MetadataType> extends FileRef<MetadataType> { }
 
-    get(): Object[];
-    hasNext(): boolean;
-    next(): Object;
-    hasPrevious(): boolean;
-    previous(): Object;
-    first(): Object;
-    last(): Object;
-    remove(callback: (err) => void): void;
-    each(): FileCursor<MetadataType>[];
-    current(): Object | undefined;
-  }
+
+	export class FilesCursor<MetadataType, TransformAdditions> extends Mongo.Cursor<FileObj<MetadataType>> {
+		cursor: Mongo.Cursor<FileObj<MetadataType>>; // Refers to base cursor? Why is this existing?
+
+		get(): Array<FileCursor<MetadataType> & TransformAdditions>;
+		hasNext(): boolean;
+		next(): FileCursor<MetadataType> & TransformAdditions;
+		hasPrevious(): boolean;
+		previous(): FileCursor<MetadataType> & TransformAdditions;
+		first(): FileCursor<MetadataType> & TransformAdditions;
+		last(): FileCursor<MetadataType> & TransformAdditions;
+		remove(callback: (err: Object) => void): void;
+		each(): Array<FileCursor<MetadataType> & TransformAdditions>;
+		current(): Object | undefined;
+	}
 
 
   export class FilesCollection<MetadataType = { [x: string]: any }> {
-    collection: Mongo.Collection<FileObj<MetadataType>>;
-    schema: SimpleSchemaDefinition;
+		collection: Mongo.Collection<FileObj<MetadataType>>;
+		schema: SimpleSchemaDefinition;
 
-    constructor(config: FilesCollectionConfig<MetadataType>)
+		constructor(config: FilesCollectionConfig<MetadataType>)
 
     /**
      * Find and return Cursor for matching documents.
@@ -185,28 +179,34 @@ declare module "meteor/ostrio:files" {
      * @param selector [[http://docs.meteor.com/api/collections.html#selectors | Mongo-Style selector]]
      * @param options [[http://docs.meteor.com/api/collections.html#sortspecifiers | Mongo-Style selector Options]]
     
-     * @typeParam TransformedType The result of transforming a document with options.tranform().
+     * @template TransformAdditions Additional properties provided by transforming a document with options.tranform(). 
+     *            Note that removing fields with a transform function is not currently supported as this may break 
+     *            functions defined on a FileRef or FileCursor.
      */
-    find<TransformedType = FileRef<MetadataType>>(selector?: Mongo.Selector<Partial<FileObj<MetadataType>>>, options?: SearchOptions<MetadataType, TransformedType>): FilesCursor<TransformedType>;
+    find<TransformAdditions = {}>(selector?: Mongo.Selector<Partial<FileObj<MetadataType>>>, options?: SearchOptions<MetadataType, TransformAdditions>): FilesCursor<MetadataType, TransformAdditions>;
+    
     /**
      * Finds the first document that matches the selector, as ordered by sort and skip options.
      * 
      * @param selector [[http://docs.meteor.com/api/collections.html#selectors | Mongo-Style selector]]
      * @param options [[http://docs.meteor.com/api/collections.html#sortspecifiers | Mongo-Style selector Options]]
-    
-     * @typeParam TransformedType The result of transforming a document with options.tranform().
+     * 
+     * @template TransformAdditions Additional properties provided by transforming a document with options.tranform().
+     *            Note that removing fields with a transform function is not currently supported as this may break 
+     *            functions defined on a FileRef or FileCursor.
      */
-    findOne<TransformedType = FileRef<MetadataType>>(selector?: Mongo.Selector<Partial<FileObj<MetadataType>>> | string, options?: SearchOptions<MetadataType, TransformedType>): FileCursor<TransformedType>;
+    findOne<TransformAdditions = {}>(selector?: Mongo.Selector<Partial<FileObj<MetadataType>>> | string, options?: SearchOptions<MetadataType, TransformAdditions>): FileCursor<MetadataType> & TransformAdditions;
+    
     insert(settings: InsertOptions<MetadataType>, autoStart?: boolean): FileUpload;
-    remove(select: Mongo.Selector<FileObj<MetadataType>> | string, callback?: (error: Object) => Object): FilesCollection<MetadataType>;
-    link(fileRef: FileRef<MetadataType>, version?: string): string;
-    allow(options: Mongo.AllowDenyOptions): void;
-    deny(options: Mongo.AllowDenyOptions): void;
-    denyClient(): void;
-    on(event: string, callback: (fileRef: FileRef<MetadataType>) => void): void;
-    unlink(fileRef: FileRef<MetadataType>, version?: string): FilesCollection<MetadataType>;
-    addFile(path: string, opts: LoadOptions<MetadataType>, callback: (err: any, fileRef: FileRef<MetadataType>) => any, proceedAfterUpload: boolean): FilesCollection<MetadataType>;
-    load(url: string, opts: LoadOptions<MetadataType>, callback: (err: Object, fileRef: FileRef<MetadataType>) => any, proceedAfterUpload: boolean): FilesCollection<MetadataType>;
-    write(buffer: Buffer, opts: LoadOptions<MetadataType>, callback: (err: Object, fileRef: FileRef<MetadataType>) => any, proceedAfterUpload: boolean): FilesCollection<MetadataType>;
-  }
+		remove(select: Mongo.Selector<FileObj<MetadataType>> | string, callback?: (error: Object) => Object): FilesCollection<MetadataType>;
+		link(fileRef: FileRef<MetadataType>, version?: string): string;
+		allow(options: Mongo.AllowDenyOptions): void;
+		deny(options: Mongo.AllowDenyOptions): void;
+		denyClient(): void;
+		on(event: string, callback: (fileRef: FileRef<MetadataType>) => void): void;
+		unlink(fileRef: FileRef<MetadataType>, version?: string): FilesCollection<MetadataType>;
+		addFile(path: string, opts: LoadOptions<MetadataType>, callback: (err: any, fileRef: FileRef<MetadataType>) => any, proceedAfterUpload: boolean): FilesCollection<MetadataType>;
+		load(url: string, opts: LoadOptions<MetadataType>, callback: (err: Object, fileRef: FileRef<MetadataType>) => any, proceedAfterUpload: boolean): FilesCollection<MetadataType>;
+		write(buffer: Buffer, opts: LoadOptions<MetadataType>, callback: (err: Object, fileRef: FileRef<MetadataType>) => any, proceedAfterUpload: boolean): FilesCollection<MetadataType>;
+	}
 }


### PR DESCRIPTION
Sorry, realised later that I'd stuffed up how the types for the options.transform function in find and findOne functions was handled. See comments for find() and findOne() in the defs for more info...

- Fixes handling of types for options.transform function in find and findOne.
- Adds specific types to FilesCursor functions.
