### PR TITLE
Fix: wrong links in public mode

### DIFF
--- a/cursor.js
+++ b/cursor.js
@@ -10,6 +10,7 @@ import { Meteor } from 'meteor/meteor';
  */
 export class FileCursor {
   constructor(_fileRef, _collection) {
+    _fileRef.public = _collection.public;
     this._fileRef    = _fileRef;
     this._collection = _collection;
     Object.assign(this, _fileRef);


### PR DESCRIPTION
Sorry, I haven't created an issue before.

Function formatFleURL() check public mode [here](https://github.com/veliovgroup/Meteor-Files/blob/9f2aace393657c3f88af5664667f4b115b49f06f/lib.js#L200) to return correct link in public mode that is bypassing Meteor.

But 'fileRef' object had no 'public' property defined so returned link always pointed to the file served by Meteor instead of web server.


