### PR TITLE
📦 v2.2.1

### DIFF
--- a/.versions
+++ b/.versions
@@ -21,7 +21,7 @@ fetch@0.1.1
 geojson-utils@1.0.10
 id-map@1.1.1
 inter-process-messaging@0.1.1
-local-test:ostrio:files@2.2.0
+local-test:ostrio:files@2.2.1
 logging@1.3.1
 meteor@1.10.0
 minimongo@1.8.0
@@ -35,7 +35,7 @@ mongo-id@1.0.8
 npm-mongo@4.3.1
 ordered-dict@1.1.0
 ostrio:cookies@2.7.2
-ostrio:files@2.2.0
+ostrio:files@2.2.1
 promise@0.12.0
 random@1.2.0
 react-fast-refresh@0.2.3

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'ostrio:files',
-  version: '2.2.0',
+  version: '2.2.1',
   summary: 'Upload files to a server or 3rd party storage: AWS:S3, GridFS, DropBox, and other',
   git: 'https://github.com/veliovgroup/Meteor-Files',
   documentation: 'README.md'

--- a/server.js
+++ b/server.js
@@ -1254,9 +1254,12 @@ class FilesCollection extends FilesCollectionCore {
 
     result._id = fileId;
 
-    fs.stat(opts.path, (statErr, stats) => {
+    fs.stat(opts.path, (statError, stats) => {
       bound(() => {
-        if (statErr || !stats.isFile()) {
+        if (statError || !stats.isFile()) {
+          const paths = opts.path.split('/');
+          paths.pop();
+          fs.mkdirSync(paths.join('/'), { recursive: true });
           fs.writeFileSync(opts.path, '');
         }
 
@@ -1364,9 +1367,12 @@ class FilesCollection extends FilesCollectionCore {
       });
     };
 
-    fs.stat(opts.path, (statErr, stats) => {
+    fs.stat(opts.path, (statError, stats) => {
       bound(() => {
-        if (statErr || !stats.isFile()) {
+        if (statError || !stats.isFile()) {
+          const paths = opts.path.split('/');
+          paths.pop();
+          fs.mkdirSync(paths.join('/'), { recursive: true });
           fs.writeFileSync(opts.path, '');
         }
 
@@ -1394,10 +1400,10 @@ class FilesCollection extends FilesCollectionCore {
               });
 
               if (!result.size) {
-                fs.stat(opts.path, (statError, newStats) => {
+                fs.stat(opts.path, (statErrorOnEnd, newStats) => {
                   bound(() => {
-                    if (statError) {
-                      callback && callback(statError);
+                    if (statErrorOnEnd) {
+                      callback && callback(statErrorOnEnd);
                     } else {
                       result.versions.original.size = (result.size = newStats.size);
                       storeResult(result, callback);

--- a/write-stream.js
+++ b/write-stream.js
@@ -47,6 +47,7 @@ export default class WriteStream {
             fs.mkdirSync(paths.join('/'), { recursive: true });
             fs.writeFileSync(this.path, '');
           }
+
           fs.open(this.path, 'r+', this.permissions, (oError, fd) => {
             bound(() => {
               if (oError) {


### PR DESCRIPTION
-  👨‍💻 Fix #842, a newly detected bug by @chrschae; Fixing case when `namingFunction` returns new nested path cause exception in `.write()` and `.load()` methods