### PR TITLE
Set httpOnly to false

### DIFF
--- a/client.js
+++ b/client.js
@@ -115,7 +115,7 @@ class FilesCollection extends FilesCollectionCore {
     if (!config.disableSetTokenCookie) {
       const setTokenCookie = () => {
         if (Meteor.connection._lastSessionId) {
-          cookie.set('x_mtok', Meteor.connection._lastSessionId, { path: '/', sameSite: 'Lax', secure: true, httpOnly: true });
+          cookie.set('x_mtok', Meteor.connection._lastSessionId, { path: '/', sameSite: 'Lax', secure: true });
           if ((Meteor.isCordova || Meteor.isDesktop) && this.allowQueryStringCookies) {
             cookie.send();
           }


### PR DESCRIPTION
httpOnly flag is a server side flag, adding it to the client side cookie creation code invalidates it. 

It's definitely possible that we can move the token creation to the server-side for more secure tokens but it's necessary to have you green light it first @dr-dimitru  

I'm thinking we inject the token somewhere here:
https://github.com/veliovgroup/Meteor-Files/blob/1ed12d1b0a328c873b40406424071e33794dbf10/server.js#L526

and we completely remove the need to instantiate the token on the client side. Do you have any objections? Let me know about the best route and I'll gladly implement it.

I'm even more interested as to why you did it this way. Why was it created on the client side then sent to the server. Another peculiar problem is why do you rely on the `lastSessionId` to validate the request and locate the user. Why not store the usual Meteor local storage token in the cookie and use it later on to retrieve the user. This is one of the most unique was I've ever encountered in Meteor.

Thanks to @fidelsam1992 / @determinds for pointing this out and the time/money. :grin: