### PR TITLE
async support added for storagePath() function

### DIFF
--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -239,7 +239,7 @@ describe('FilesCollection', () => {
 
       const opts = { name: 'test.txt', type: 'text/plain', meta: {}, userId: 'user1', fileId: 'file1' };
 
-      sinon.stub(filesCollection, 'storagePath').returns('~/data');
+      sinon.stub(filesCollection, 'storagePath').resolves('~/data');
       fsPromiseStatStub.restore();
       fsPromiseWriteFileStub.restore();
       fsPromisesMkdirStub.restore();


### PR DESCRIPTION
Hi,
I’m using ostrio:files in a Meteor project and ran into a limitation regarding `storagePath()`.

### Current behavior

`storagePath()` is called synchronously, which makes it impossible to compute the value using asynchronous operations.

Example use cases where async is required:
- Fetching storage directory from an external API/microservice
- Reading path from a database
- Using dynamic per-user storage resolution that requires async lookups
- Awaiting cloud / remote mount status before determining path

Right now, returning a Promise or using async/await inside storagePath() does not work — the function must return a string immediately.

### Impact

This prevents:
- Multi-tenant storage routing
- User-specific or organization-specific folders resolved from DB
- Integration with remote storage services that determine the directory dynamically
- Compatibility with applications where storage rules are not fully known at startup

### Desired behavior

Allow `storagePath()` to be asynchronous.

Example idea:
```
new FilesCollection({
  storagePath: async (fileObj) => {
    const dir = await getBucketFromDB(fileObj.userId);
    return `/mnt/data/${dir}`;
  }
});
```